### PR TITLE
Migrating multitask.ipynb to TFDS

### DIFF
--- a/tensorflow_recommenders/examples/multitask.ipynb
+++ b/tensorflow_recommenders/examples/multitask.ipynb
@@ -234,10 +234,10 @@
     {
      "data": {
       "text/plain": [
-       "<tensorflow_recommenders.tasks.ranking.RankingTask at 0x7ff2a8d7be10>"
+       "<tensorflow_recommenders.tasks.ranking.RankingTask at 0x7fcc323c5d68>"
       ]
      },
-     "execution_count": 39,
+     "execution_count": 6,
      "metadata": {
       "tags": []
      },
@@ -247,7 +247,7 @@
    "source": [
     "tfrs.tasks.RankingTask(\n",
     "    loss=tf.keras.losses.MeanSquaredError(),\n",
-    "    metrics=[tf.keras.metrics.MeanSquaredError()],\n",
+    "    metrics=[tf.keras.metrics.RootMeanSquaredError()],\n",
     ")"
    ]
   },
@@ -278,10 +278,10 @@
     {
      "data": {
       "text/plain": [
-       "<tensorflow_recommenders.tasks.retrieval.RetrievalTask at 0x7ff2a781f2e8>"
+       "<tensorflow_recommenders.tasks.retrieval.RetrievalTask at 0x7fcc2464ba90>"
       ]
      },
-     "execution_count": 40,
+     "execution_count": 7,
      "metadata": {
       "tags": []
      },
@@ -354,7 +354,7 @@
     "    # The tasks.\n",
     "    self.rating_task: tf.keras.layers.Layer = tfrs.tasks.RankingTask(\n",
     "        loss=tf.keras.losses.MeanSquaredError(),\n",
-    "        metrics=[tf.keras.metrics.MeanSquaredError()],\n",
+    "        metrics=[tf.keras.metrics.RootMeanSquaredError()],\n",
     "    )\n",
     "    self.retrieval_task: tf.keras.layers.Layer = tfrs.tasks.RetrievalTask(\n",
     "        corpus_metrics=tfrs.metrics.FactorizedTopK(\n",
@@ -469,28 +469,28 @@
      "output_type": "stream",
      "text": [
       "Epoch 1/3\n",
-      "10/10 [==============================] - 22s 2s/step - mean_squared_error: 7.7681 - factorized_top_k_7: 0.0189 - factorized_top_k_7/top_1_categorical_accuracy: 2.1250e-04 - factorized_top_k_7/top_5_categorical_accuracy: 0.0023 - factorized_top_k_7/top_10_categorical_accuracy: 0.0053 - factorized_top_k_7/top_50_categorical_accuracy: 0.0285 - factorized_top_k_7/top_100_categorical_accuracy: 0.0581 - loss: 7.1756\n",
+      "10/10 [==============================] - 20s 2s/step - root_mean_squared_error: 2.8151 - factorized_top_k_1: 0.0189 - factorized_top_k_1/top_1_categorical_accuracy: 2.1250e-04 - factorized_top_k_1/top_5_categorical_accuracy: 0.0023 - factorized_top_k_1/top_10_categorical_accuracy: 0.0053 - factorized_top_k_1/top_50_categorical_accuracy: 0.0284 - factorized_top_k_1/top_100_categorical_accuracy: 0.0581 - loss: 7.1756\n",
       "Epoch 2/3\n",
-      "10/10 [==============================] - 21s 2s/step - mean_squared_error: 1.2631 - factorized_top_k_7: 0.0189 - factorized_top_k_7/top_1_categorical_accuracy: 2.1250e-04 - factorized_top_k_7/top_5_categorical_accuracy: 0.0024 - factorized_top_k_7/top_10_categorical_accuracy: 0.0054 - factorized_top_k_7/top_50_categorical_accuracy: 0.0284 - factorized_top_k_7/top_100_categorical_accuracy: 0.0583 - loss: 1.2576\n",
+      "10/10 [==============================] - 20s 2s/step - root_mean_squared_error: 1.1245 - factorized_top_k_1: 0.0189 - factorized_top_k_1/top_1_categorical_accuracy: 2.1250e-04 - factorized_top_k_1/top_5_categorical_accuracy: 0.0024 - factorized_top_k_1/top_10_categorical_accuracy: 0.0054 - factorized_top_k_1/top_50_categorical_accuracy: 0.0284 - factorized_top_k_1/top_100_categorical_accuracy: 0.0583 - loss: 1.2576\n",
       "Epoch 3/3\n",
-      "10/10 [==============================] - 22s 2s/step - mean_squared_error: 1.2382 - factorized_top_k_7: 0.0190 - factorized_top_k_7/top_1_categorical_accuracy: 2.5000e-04 - factorized_top_k_7/top_5_categorical_accuracy: 0.0024 - factorized_top_k_7/top_10_categorical_accuracy: 0.0054 - factorized_top_k_7/top_50_categorical_accuracy: 0.0287 - factorized_top_k_7/top_100_categorical_accuracy: 0.0583 - loss: 1.2337\n",
-      "5/5 [==============================] - 3s 638ms/step - mean_squared_error: 1.2281 - factorized_top_k_7: 0.0190 - factorized_top_k_7/top_1_categorical_accuracy: 2.5000e-04 - factorized_top_k_7/top_5_categorical_accuracy: 0.0026 - factorized_top_k_7/top_10_categorical_accuracy: 0.0063 - factorized_top_k_7/top_50_categorical_accuracy: 0.0281 - factorized_top_k_7/top_100_categorical_accuracy: 0.0578 - loss: 1.2236\n"
+      "10/10 [==============================] - 20s 2s/step - root_mean_squared_error: 1.1133 - factorized_top_k_1: 0.0190 - factorized_top_k_1/top_1_categorical_accuracy: 2.6250e-04 - factorized_top_k_1/top_5_categorical_accuracy: 0.0024 - factorized_top_k_1/top_10_categorical_accuracy: 0.0054 - factorized_top_k_1/top_50_categorical_accuracy: 0.0287 - factorized_top_k_1/top_100_categorical_accuracy: 0.0583 - loss: 1.2337\n",
+      "5/5 [==============================] - 3s 628ms/step - root_mean_squared_error: 1.1085 - factorized_top_k_1: 0.0190 - factorized_top_k_1/top_1_categorical_accuracy: 2.5000e-04 - factorized_top_k_1/top_5_categorical_accuracy: 0.0026 - factorized_top_k_1/top_10_categorical_accuracy: 0.0063 - factorized_top_k_1/top_50_categorical_accuracy: 0.0281 - factorized_top_k_1/top_100_categorical_accuracy: 0.0578 - loss: 1.2236\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "{'factorized_top_k_7': array([0.00025, 0.0026 , 0.00625, 0.0281 , 0.0578 ], dtype=float32),\n",
-       " 'factorized_top_k_7/top_100_categorical_accuracy': 0.05779999867081642,\n",
-       " 'factorized_top_k_7/top_10_categorical_accuracy': 0.0062500000931322575,\n",
-       " 'factorized_top_k_7/top_1_categorical_accuracy': 0.0002500000118743628,\n",
-       " 'factorized_top_k_7/top_50_categorical_accuracy': 0.02810000069439411,\n",
-       " 'factorized_top_k_7/top_5_categorical_accuracy': 0.0026000000070780516,\n",
+       "{'factorized_top_k_1': array([0.00025, 0.0026 , 0.00625, 0.0281 , 0.0578 ], dtype=float32),\n",
+       " 'factorized_top_k_1/top_100_categorical_accuracy': 0.05779999867081642,\n",
+       " 'factorized_top_k_1/top_10_categorical_accuracy': 0.0062500000931322575,\n",
+       " 'factorized_top_k_1/top_1_categorical_accuracy': 0.0002500000118743628,\n",
+       " 'factorized_top_k_1/top_50_categorical_accuracy': 0.02810000069439411,\n",
+       " 'factorized_top_k_1/top_5_categorical_accuracy': 0.0026000000070780516,\n",
        " 'loss': 1.2009674310684204,\n",
-       " 'mean_squared_error': 1.2281196117401123}"
+       " 'root_mean_squared_error': 1.108499526977539}"
       ]
      },
-     "execution_count": 44,
+     "execution_count": 11,
      "metadata": {
       "tags": []
      },
@@ -509,7 +509,7 @@
     "id": "lENViv04-i0T"
    },
    "source": [
-    "The model does OK on predicting ratings (with an MSE of around 1.23), but performs poorly at predicting which movies will be watched or not: its accuracy at 100 is almost 4 times worse than a model trained solely to predict watches."
+    "The model does OK on predicting ratings (with an RMSE of around 1.11), but performs poorly at predicting which movies will be watched or not: its accuracy at 100 is almost 4 times worse than a model trained solely to predict watches."
    ]
   },
   {
@@ -566,28 +566,28 @@
      "output_type": "stream",
      "text": [
       "Epoch 1/3\n",
-      "10/10 [==============================] - 21s 2s/step - mean_squared_error: 13.9885 - factorized_top_k_8: 0.0249 - factorized_top_k_8/top_1_categorical_accuracy: 1.5000e-04 - factorized_top_k_8/top_5_categorical_accuracy: 0.0026 - factorized_top_k_8/top_10_categorical_accuracy: 0.0063 - factorized_top_k_8/top_50_categorical_accuracy: 0.0382 - factorized_top_k_8/top_100_categorical_accuracy: 0.0773 - loss: 70229.4489\n",
+      "10/10 [==============================] - 20s 2s/step - root_mean_squared_error: 3.7399 - factorized_top_k_2: 0.0248 - factorized_top_k_2/top_1_categorical_accuracy: 1.7500e-04 - factorized_top_k_2/top_5_categorical_accuracy: 0.0026 - factorized_top_k_2/top_10_categorical_accuracy: 0.0062 - factorized_top_k_2/top_50_categorical_accuracy: 0.0380 - factorized_top_k_2/top_100_categorical_accuracy: 0.0772 - loss: 70229.4489\n",
       "Epoch 2/3\n",
-      "10/10 [==============================] - 22s 2s/step - mean_squared_error: 14.0427 - factorized_top_k_8: 0.0981 - factorized_top_k_8/top_1_categorical_accuracy: 0.0012 - factorized_top_k_8/top_5_categorical_accuracy: 0.0156 - factorized_top_k_8/top_10_categorical_accuracy: 0.0340 - factorized_top_k_8/top_50_categorical_accuracy: 0.1604 - factorized_top_k_8/top_100_categorical_accuracy: 0.2791 - loss: 67823.9311\n",
+      "10/10 [==============================] - 20s 2s/step - root_mean_squared_error: 3.7470 - factorized_top_k_2: 0.0979 - factorized_top_k_2/top_1_categorical_accuracy: 0.0012 - factorized_top_k_2/top_5_categorical_accuracy: 0.0155 - factorized_top_k_2/top_10_categorical_accuracy: 0.0340 - factorized_top_k_2/top_50_categorical_accuracy: 0.1602 - factorized_top_k_2/top_100_categorical_accuracy: 0.2787 - loss: 67823.9311\n",
       "Epoch 3/3\n",
-      "10/10 [==============================] - 22s 2s/step - mean_squared_error: 14.0935 - factorized_top_k_8: 0.1169 - factorized_top_k_8/top_1_categorical_accuracy: 0.0022 - factorized_top_k_8/top_5_categorical_accuracy: 0.0233 - factorized_top_k_8/top_10_categorical_accuracy: 0.0465 - factorized_top_k_8/top_50_categorical_accuracy: 0.1928 - factorized_top_k_8/top_100_categorical_accuracy: 0.3196 - loss: 66386.3928\n",
-      "5/5 [==============================] - 4s 729ms/step - mean_squared_error: 14.1269 - factorized_top_k_8: 0.0640 - factorized_top_k_8/top_1_categorical_accuracy: 5.0000e-04 - factorized_top_k_8/top_5_categorical_accuracy: 0.0054 - factorized_top_k_8/top_10_categorical_accuracy: 0.0144 - factorized_top_k_8/top_50_categorical_accuracy: 0.0990 - factorized_top_k_8/top_100_categorical_accuracy: 0.2007 - loss: 31386.0449\n"
+      "10/10 [==============================] - 20s 2s/step - root_mean_squared_error: 3.7538 - factorized_top_k_2: 0.1163 - factorized_top_k_2/top_1_categorical_accuracy: 0.0021 - factorized_top_k_2/top_5_categorical_accuracy: 0.0228 - factorized_top_k_2/top_10_categorical_accuracy: 0.0460 - factorized_top_k_2/top_50_categorical_accuracy: 0.1919 - factorized_top_k_2/top_100_categorical_accuracy: 0.3188 - loss: 66386.3928\n",
+      "5/5 [==============================] - 3s 694ms/step - root_mean_squared_error: 3.7586 - factorized_top_k_2: 0.0640 - factorized_top_k_2/top_1_categorical_accuracy: 5.0000e-04 - factorized_top_k_2/top_5_categorical_accuracy: 0.0054 - factorized_top_k_2/top_10_categorical_accuracy: 0.0144 - factorized_top_k_2/top_50_categorical_accuracy: 0.0990 - factorized_top_k_2/top_100_categorical_accuracy: 0.2007 - loss: 31386.0449\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "{'factorized_top_k_8': array([0.0005 , 0.00535, 0.0144 , 0.099  , 0.2007 ], dtype=float32),\n",
-       " 'factorized_top_k_8/top_100_categorical_accuracy': 0.20069999992847443,\n",
-       " 'factorized_top_k_8/top_10_categorical_accuracy': 0.014399999752640724,\n",
-       " 'factorized_top_k_8/top_1_categorical_accuracy': 0.0005000000237487257,\n",
-       " 'factorized_top_k_8/top_50_categorical_accuracy': 0.0989999994635582,\n",
-       " 'factorized_top_k_8/top_5_categorical_accuracy': 0.005350000225007534,\n",
+       "{'factorized_top_k_2': array([0.0005 , 0.00535, 0.0144 , 0.099  , 0.2007 ], dtype=float32),\n",
+       " 'factorized_top_k_2/top_100_categorical_accuracy': 0.20069999992847443,\n",
+       " 'factorized_top_k_2/top_10_categorical_accuracy': 0.014399999752640724,\n",
+       " 'factorized_top_k_2/top_1_categorical_accuracy': 0.0005000000237487257,\n",
+       " 'factorized_top_k_2/top_50_categorical_accuracy': 0.0989999994635582,\n",
+       " 'factorized_top_k_2/top_5_categorical_accuracy': 0.005350000225007534,\n",
        " 'loss': 28544.43359375,\n",
-       " 'mean_squared_error': 14.126886367797852}"
+       " 'root_mean_squared_error': 3.758612871170044}"
       ]
      },
-     "execution_count": 46,
+     "execution_count": 13,
      "metadata": {
       "tags": []
      },
@@ -663,28 +663,28 @@
      "output_type": "stream",
      "text": [
       "Epoch 1/3\n",
-      "10/10 [==============================] - 22s 2s/step - mean_squared_error: 7.2046 - factorized_top_k_9: 0.0270 - factorized_top_k_9/top_1_categorical_accuracy: 2.6250e-04 - factorized_top_k_9/top_5_categorical_accuracy: 0.0032 - factorized_top_k_9/top_10_categorical_accuracy: 0.0070 - factorized_top_k_9/top_50_categorical_accuracy: 0.0413 - factorized_top_k_9/top_100_categorical_accuracy: 0.0833 - loss: 70187.2571\n",
+      "10/10 [==============================] - 20s 2s/step - root_mean_squared_error: 2.7100 - factorized_top_k_3: 0.0267 - factorized_top_k_3/top_1_categorical_accuracy: 2.7500e-04 - factorized_top_k_3/top_5_categorical_accuracy: 0.0031 - factorized_top_k_3/top_10_categorical_accuracy: 0.0067 - factorized_top_k_3/top_50_categorical_accuracy: 0.0408 - factorized_top_k_3/top_100_categorical_accuracy: 0.0826 - loss: 70187.2571\n",
       "Epoch 2/3\n",
-      "10/10 [==============================] - 21s 2s/step - mean_squared_error: 1.3413 - factorized_top_k_9: 0.0999 - factorized_top_k_9/top_1_categorical_accuracy: 0.0011 - factorized_top_k_9/top_5_categorical_accuracy: 0.0162 - factorized_top_k_9/top_10_categorical_accuracy: 0.0351 - factorized_top_k_9/top_50_categorical_accuracy: 0.1629 - factorized_top_k_9/top_100_categorical_accuracy: 0.2840 - loss: 67747.3771\n",
+      "10/10 [==============================] - 20s 2s/step - root_mean_squared_error: 1.1583 - factorized_top_k_3: 0.0990 - factorized_top_k_3/top_1_categorical_accuracy: 9.6250e-04 - factorized_top_k_3/top_5_categorical_accuracy: 0.0158 - factorized_top_k_3/top_10_categorical_accuracy: 0.0344 - factorized_top_k_3/top_50_categorical_accuracy: 0.1614 - factorized_top_k_3/top_100_categorical_accuracy: 0.2826 - loss: 67747.3771\n",
       "Epoch 3/3\n",
-      "10/10 [==============================] - 21s 2s/step - mean_squared_error: 1.2879 - factorized_top_k_9: 0.1168 - factorized_top_k_9/top_1_categorical_accuracy: 0.0022 - factorized_top_k_9/top_5_categorical_accuracy: 0.0229 - factorized_top_k_9/top_10_categorical_accuracy: 0.0461 - factorized_top_k_9/top_50_categorical_accuracy: 0.1923 - factorized_top_k_9/top_100_categorical_accuracy: 0.3204 - loss: 66387.5078\n",
-      "5/5 [==============================] - 4s 732ms/step - mean_squared_error: 1.2156 - factorized_top_k_9: 0.0632 - factorized_top_k_9/top_1_categorical_accuracy: 4.5000e-04 - factorized_top_k_9/top_5_categorical_accuracy: 0.0050 - factorized_top_k_9/top_10_categorical_accuracy: 0.0118 - factorized_top_k_9/top_50_categorical_accuracy: 0.0984 - factorized_top_k_9/top_100_categorical_accuracy: 0.2005 - loss: 31402.9049\n"
+      "10/10 [==============================] - 20s 2s/step - root_mean_squared_error: 1.1351 - factorized_top_k_3: 0.1166 - factorized_top_k_3/top_1_categorical_accuracy: 0.0022 - factorized_top_k_3/top_5_categorical_accuracy: 0.0227 - factorized_top_k_3/top_10_categorical_accuracy: 0.0459 - factorized_top_k_3/top_50_categorical_accuracy: 0.1922 - factorized_top_k_3/top_100_categorical_accuracy: 0.3202 - loss: 66387.5078\n",
+      "5/5 [==============================] - 4s 706ms/step - root_mean_squared_error: 1.1030 - factorized_top_k_3: 0.0632 - factorized_top_k_3/top_1_categorical_accuracy: 4.5000e-04 - factorized_top_k_3/top_5_categorical_accuracy: 0.0050 - factorized_top_k_3/top_10_categorical_accuracy: 0.0118 - factorized_top_k_3/top_50_categorical_accuracy: 0.0984 - factorized_top_k_3/top_100_categorical_accuracy: 0.2005 - loss: 31402.9049\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "{'factorized_top_k_9': array([0.00045, 0.00505, 0.0118 , 0.0984 , 0.2005 ], dtype=float32),\n",
-       " 'factorized_top_k_9/top_100_categorical_accuracy': 0.2004999965429306,\n",
-       " 'factorized_top_k_9/top_10_categorical_accuracy': 0.011800000444054604,\n",
-       " 'factorized_top_k_9/top_1_categorical_accuracy': 0.00044999999227002263,\n",
-       " 'factorized_top_k_9/top_50_categorical_accuracy': 0.09839999675750732,\n",
-       " 'factorized_top_k_9/top_5_categorical_accuracy': 0.005049999803304672,\n",
+       "{'factorized_top_k_3': array([0.00045, 0.00505, 0.0118 , 0.0984 , 0.2005 ], dtype=float32),\n",
+       " 'factorized_top_k_3/top_100_categorical_accuracy': 0.2004999965429306,\n",
+       " 'factorized_top_k_3/top_10_categorical_accuracy': 0.011800000444054604,\n",
+       " 'factorized_top_k_3/top_1_categorical_accuracy': 0.00044999999227002263,\n",
+       " 'factorized_top_k_3/top_50_categorical_accuracy': 0.09839999675750732,\n",
+       " 'factorized_top_k_3/top_5_categorical_accuracy': 0.005049999803304672,\n",
        " 'loss': 28558.087890625,\n",
-       " 'mean_squared_error': 1.2155885696411133}"
+       " 'root_mean_squared_error': 1.1030011177062988}"
       ]
      },
-     "execution_count": 48,
+     "execution_count": 15,
      "metadata": {
       "tags": []
      },
@@ -703,7 +703,7 @@
     "id": "Ni_rkOsaB3f9"
    },
    "source": [
-    "The result is a model that performs almost as well as the retrieval-specialized model on retrieval tasks and performs slightly better than the rating-specialized model on rating tasks. This is the promise of transfer learning, where jointly training a model on a set of related tasks can result in a better model that training a set of separate estimators.\n",
+    "The result is a model that performs almost as well as the retrieval-specialized model on retrieval tasks and performs slightly better than the rating-specialized model on rating tasks. The latter result shows the promise of transfer learning, where jointly training a model on a set of related tasks can result in a better model that training a set of separate estimators.\n",
     "\n",
     "Of course, this is not true everywhere. We can expect better results when tasks are closely related, or when we can trasnfer knowledge from a data-abundant task (such as clicks) to a related data-sparse task (such as purchases)."
    ]


### PR DESCRIPTION
This pull request makes the following changes:

- Switch to use TFDS MovieLens dataset.

- Rewrites the user model and the movie model with subclassing.

- Changes the numbers of training epochs from 10 to 3 to avoid overfitting and for faster runtime.

@vancezuo @maciejkula Could you review this PR please?