### PR TITLE
DOC Fix link typo

### DIFF
--- a/docs/examples/basic_ranking.ipynb
+++ b/docs/examples/basic_ranking.ipynb
@@ -531,7 +531,7 @@
         "\n",
         "Of course, making a practical ranking system requires much more effort.\n",
         "\n",
-        "In most cases, a ranking model can be substantially improved by using more features rather than just user and candidate identifiers. To see how to do that, have a look at the [side features](fearutization) tutorial.\n",
+        "In most cases, a ranking model can be substantially improved by using more features rather than just user and candidate identifiers. To see how to do that, have a look at the [side features](featurization) tutorial.\n",
         "\n",
         "A careful understanding of the objectives worth optimizing is also necessary. To get started on building a recommender that optimizes multiple objectives, have a look at our [multitask](multitask) tutorial."
       ]


### PR DESCRIPTION
Fix link typo in `basic_ranking.ipynb` notebook.