### PR TITLE
DOC Fix deprecation warning

### DIFF
--- a/docs/examples/quickstart.ipynb
+++ b/docs/examples/quickstart.ipynb
@@ -135,9 +135,9 @@
       "outputs": [],
       "source": [
         "# Ratings data.\n",
-        "ratings = tfds.load('movie_lens/100k-ratings', split=\"train\")\n",
+        "ratings = tfds.load('movielens/100k-ratings', split=\"train\")\n",
         "# Features of all the available movies.\n",
-        "movies = tfds.load('movie_lens/100k-movies', split=\"train\")\n",
+        "movies = tfds.load('movielens/100k-movies', split=\"train\")\n",
         "\n",
         "# Select the basic features.\n",
         "ratings = ratings.map(lambda x: {\n",


### PR DESCRIPTION
Fix deprecation warning:
```
WARNING:absl:The handle "movie_lens" for the MovieLens dataset is deprecated. Prefer using "movielens" instead.
```