### PR TITLE
fix factorized_top_k do not exist in tfrs.layers

### DIFF
--- a/docs/examples/quickstart.ipynb
+++ b/docs/examples/quickstart.ipynb
@@ -292,7 +292,7 @@
         "model.fit(ratings.batch(4096), epochs=3)\n",
         "\n",
         "# Use brute-force search to set up retrieval using the trained representations.\n",
-        "index = tfrs.layers.factorized_top_k.BruteForce(model.user_model)\n",
+        "index = tfrs.layers.ann.BruteForce(model.user_model) \n",
         "index.index(movies.batch(100).map(model.movie_model), movies)\n",
         "\n",
         "# Get some recommendations.\n",


### PR DESCRIPTION
replace reference to BruteForce with the correct localization in tfrs.layers.ann instead of tfrs.layers.fix factorized_top_k https://www.tensorflow.org/recommenders/api_docs/python/tfrs/layers/ann