### PR TITLE
Fix unbound local variable in factorized_top_k.py

### DIFF
--- a/tensorflow_recommenders/layers/factorized_top_k.py
+++ b/tensorflow_recommenders/layers/factorized_top_k.py
@@ -48,6 +48,8 @@ def _wrap_batch_too_small_error(k: int):
                        "drop_remainder argument to True when batching your "
                        "candidates, or set the handle_incomplete_batches "
                        "argument to True in the constructor. ".format(k=k))
+    else:
+      raise
 
 
 def _take_along_axis(arr: tf.Tensor, indices: tf.Tensor) -> tf.Tensor:


### PR DESCRIPTION
`_wrap_batch_too_small_error` [at this location](https://github.com/tensorflow/recommenders/blob/129ea502640814325cc7ab472f4c8e6f16998fb6/tensorflow_recommenders/layers/factorized_top_k.py#L411) can silence an exception leading to an unbound `results` variable. This PR makes sure that exceptions are always re-raised.