### PR TITLE
Fix code example in docstrings

### DIFF
--- a/tensorflow_recommenders/layers/embedding/tpu_embedding_layer.py
+++ b/tensorflow_recommenders/layers/embedding/tpu_embedding_layer.py
@@ -527,7 +527,9 @@ class TPUEmbedding(tf.keras.layers.Layer):
 
     def call(self, inputs):
       embedding = self.embedding_layer(inputs)
-      logits = tf.keras.layers.Dense(1)(tf.concat(tf.nest.flatten(embedding)))
+      logits = tf.keras.layers.Dense(1)(
+        tf.concat(tf.nest.flatten(embedding)), axis=1
+      )
 
   with strategy.scope():
     embedding_optimizer = tf.keras.optimizers.Adagrad(learning_rate=0.1)

--- a/tensorflow_recommenders/layers/embedding/tpu_embedding_layer.py
+++ b/tensorflow_recommenders/layers/embedding/tpu_embedding_layer.py
@@ -528,7 +528,7 @@ class TPUEmbedding(tf.keras.layers.Layer):
     def call(self, inputs):
       embedding = self.embedding_layer(inputs)
       logits = tf.keras.layers.Dense(1)(
-        tf.concat(tf.nest.flatten(embedding)), axis=1
+        tf.concat(tf.nest.flatten(embedding), axis=1)
       )
 
   with strategy.scope():


### PR DESCRIPTION
## Summary

`tf.concat` requires argument `axis`.
I found missing this argument in docstrings one place, so I fixed it.

## Question

Is `axis=-1` correct for `tf.concat` ?

Example specify shape of Input layer as `shape=(1,)`.  So when set `axis=1`,  input data shape is expected `[batch_size, 1]` and logits shape become `[batch_size, num_features, 1]`. This logits did not be concatenated all features.

When set `axis=-1`, logits shape become `[batch_size, 1, 1]`. This logits be concatenated all features and similar processing to RankingModel (like DCN and DLRM).

https://github.com/tensorflow/recommenders/blob/baa16aa88ae445ef5ac6bdf89f70329f5f8119b9/tensorflow_recommenders/layers/embedding/tpu_embedding_layer.py#L332-L347