### PR TITLE
Fix typo in probability sampling class 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Changed
 
--   Fixed the bug in `tfrs.layers.loss.SamplingProbablityCorrection` that logits
+-   Fixed the bug in `tfrs.layers.loss.SamplingProbabilityCorrection` that logits
     should subtract the log of item probability.
 -   `tfrs.experimental.optimizers.CompositeOptimizer`: an optimizer that
     composes multiple individual optimizers which can be applied to different

--- a/tensorflow_recommenders/layers/loss.py
+++ b/tensorflow_recommenders/layers/loss.py
@@ -147,7 +147,7 @@ class RemoveAccidentalHits(tf.keras.layers.Layer):
     return logits + duplicate * MIN_FLOAT
 
 
-class SamplingProbablityCorrection(tf.keras.layers.Layer):
+class SamplingProbabilityCorrection(tf.keras.layers.Layer):
   """Sampling probability correction."""
 
   def __call__(self, logits: tf.Tensor,

--- a/tensorflow_recommenders/tasks/retrieval.py
+++ b/tensorflow_recommenders/tasks/retrieval.py
@@ -135,7 +135,7 @@ class Retrieval(tf.keras.layers.Layer, base.Task):
       scores = scores / self._temperature
 
     if candidate_sampling_probability is not None:
-      scores = layers.loss.SamplingProbablityCorrection()(
+      scores = layers.loss.SamplingProbabilityCorrection()(
           scores, candidate_sampling_probability)
 
     if candidate_ids is not None:


### PR DESCRIPTION
Not sure if you or others have noticed this misspelling. Is it too baked in and heavily referenced to change? I can also issue a deprecation warning if you're worried about changing the public interface.