### PR TITLE
remove num_candidates

### DIFF
--- a/tensorflow_recommenders/tasks/retrieval.py
+++ b/tensorflow_recommenders/tasks/retrieval.py
@@ -127,9 +127,8 @@ class Retrieval(tf.keras.layers.Layer, base.Task):
         query_embeddings, candidate_embeddings, transpose_b=True)
 
     num_queries = tf.shape(scores)[0]
-    num_candidates = tf.shape(scores)[1]
 
-    labels = tf.eye(num_queries, num_candidates)
+    labels = tf.eye(num_queries)
 
     if self._temperature is not None:
       scores = scores / self._temperature


### PR DESCRIPTION
# Context
One nice feature of the `tfrs.tasks.retrieval` task is how simple it is. Especially how it dot products equal-sized of query and candidate embeddings and internally computes the "labels" as the identity matrix. 

# This PR
* removes the computation and use of `num_candidates` as `scores.shape[1]`. The task doesn't support any kind of non-square score matrix as far as I can tell and having this extra degree of freedom actually made it harder for me to understand what was happening.

I would humbly suggest removing these bits for now and adding back in if there becomes a more general way to pass in candidates of a different shape.