### PR TITLE
Shouldn't the reference to tape be indented?

### DIFF
--- a/docs/examples/basic_retrieval.ipynb
+++ b/docs/examples/basic_retrieval.ipynb
@@ -555,7 +555,7 @@
         "\n",
         "      total_loss = loss + regularization_loss\n",
         "\n",
-        "    gradients = tape.gradient(total_loss, self.trainable_variables)\n",
+        "      gradients = tape.gradient(total_loss, self.trainable_variables)\n",
         "    self.optimizer.apply_gradients(zip(gradients, self.trainable_variables))\n",
         "\n",
         "    metrics = {metric.name: metric.result() for metric in self.metrics}\n",


### PR DESCRIPTION
given the use of `with tf.GradientTape() as tape:` shouldn't the subsequent reference to `tape` be indented so it falls within the `with` scope?