### PR TITLE
Initialize BruteForce._candidates to None

### DIFF
--- a/tensorflow_recommenders/layers/factorized_top_k.py
+++ b/tensorflow_recommenders/layers/factorized_top_k.py
@@ -522,6 +522,7 @@ class BruteForce(TopK):
     super().__init__(k=k, name=name)
 
     self.query_model = query_model
+    self._candidates = None
 
   def index(
       self,


### PR DESCRIPTION
Fixes an AttributeError when trying to check if _candidates have been set by calling index. Allows a more helpful error message to happen:

```python
    if self._candidates is None:
      raise ValueError("The `index` method must be called first to "
                       "create the retrieval index.")
```

Closes #396 