### PR TITLE
Added tfds-nightly installation

### DIFF
--- a/docs/examples/basic_ranking.ipynb
+++ b/docs/examples/basic_ranking.ipynb
@@ -91,7 +91,8 @@
       "outputs": [],
       "source": [
         "!pip install -q tensorflow-recommenders\n",
-        "!pip install -q --upgrade tensorflow-datasets"
+        "!pip install -q --upgrade tensorflow-datasets\n",
+        "!pip intall tfds-nightly"
       ]
     },
     {


### PR DESCRIPTION
Downloading MovieLens dataset throws error if nightly is not installed