### PR TITLE
Minor fix on basic_retrieval tutorial

### DIFF
--- a/docs/examples/basic_retrieval.ipynb
+++ b/docs/examples/basic_retrieval.ipynb
@@ -877,7 +877,7 @@
         "\n",
         "  # Save the index.\n",
         "  tf.saved_model.save(\n",
-        "      index,\n",
+        "      scann_index,\n",
         "      path,\n",
         "      options=tf.saved_model.SaveOptions(namespace_whitelist=[\"Scann\"])\n",
         "  )\n",


### PR DESCRIPTION
Fixed an incorrect variable name for scann model saving.