### PR TITLE
Requires tensorflow-macos package for MacOS platforms

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-tensorflow >= 2.9.0
+tensorflow >= 2.9.0; sys_platform != 'darwin'
+tensorflow-macos >= 2.9.0; sys_platform == 'darwin'
 absl-py >= 0.1.6


### PR DESCRIPTION
Hi, currently it's not possible to install tensorflow-recommenders with version newer than 0.3.0 on MacOS-machine since it requires `tensorflow >= 2.9.0` package, while it doesn't exists for macos.

Without the fix it throws:
```
ERROR: Could not find a version that satisfies the requirement tensorflow>=2.9.0 (from tensorflow-recommenders) (from versions: none)
ERROR: No matching distribution found for tensorflow>=2.9.0
```