### PR TITLE
Set lower value for clipping in SamplingProbablityCorrection

### DIFF
--- a/tensorflow_recommenders/layers/loss.py
+++ b/tensorflow_recommenders/layers/loss.py
@@ -21,6 +21,7 @@ import tensorflow as tf
 
 MAX_FLOAT = np.finfo(np.float32).max / 100.0
 MIN_FLOAT = np.finfo(np.float32).min / 100.0
+EPS_FLOAT = np.finfo(np.float32).eps / 100.0
 
 
 def _gather_elements_along_row(data: tf.Tensor,
@@ -155,4 +156,4 @@ class SamplingProbablityCorrection(tf.keras.layers.Layer):
     """Corrects the input logits to account for candidate sampling probability."""
 
     return logits - tf.math.log(
-        tf.clip_by_value(candidate_sampling_probability, 1e-6, 1.))
+        tf.clip_by_value(candidate_sampling_probability, EPS_FLOAT, 1.))


### PR DESCRIPTION
The current value of `1e-6` could be too high for larger datasets and could lead to model performance degradation. The original value was set [here](https://github.com/tensorflow/recommenders/commit/2f89ed85f0005d2368f0fae4a3028a81525bcffd).

This PR sets the value to a lower `1.1920928955078125e-09` that comes from `np.finfo(np.float32).eps / 100` in line with other clipping constants in the project.