### PR TITLE
chore: fix variable miss in Multi-task recommenders

### DIFF
--- a/docs/examples/multitask.ipynb
+++ b/docs/examples/multitask.ipynb
@@ -213,6 +213,7 @@
         "The user and movie models are as before:\n",
         "\n",
         "```python\n",
+        "embedding_dimension=32 # define the default embedding dimension\n",
         "user_model = tf.keras.Sequential([\n",
         "  tf.keras.layers.StringLookup(\n",
         "      vocabulary=unique_user_ids, mask_token=None),\n",


### PR DESCRIPTION
Bug: Multi-task recommenders embedding_dimension variable defined inner class but refer before definition.
Fix: reclaim variable embedding_dimension as 32