### PR TITLE
Added uninstall shapely package section in the tutorial notebook

### DIFF
--- a/docs/examples/ranking_tfx.ipynb
+++ b/docs/examples/ranking_tfx.ipynb
@@ -127,6 +127,31 @@
         "!pip install -U tensorflow-recommenders"
       ]
     },
+      {
+      "cell_type": "markdown",
+      "source": [
+        "### Uninstall shapely\n",
+        "\n",
+        "TODO(b/263441833) This is a temporal solution to avoid an\n",
+        "ImportError. Ultimately, it should be handled by supporting a\n",
+        "recent version of Bigquery, instead of uninstalling other extra\n",
+        "dependencies."
+      ],
+      "metadata": {
+        "id": "DCa5Bs00k3ZR"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!pip uninstall shapely -y"
+      ],
+      "metadata": {
+        "id": "mYn4k-r-k3qN"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
     {
       "cell_type": "markdown",
       "metadata": {


### PR DESCRIPTION
Recently we have made changes in our TFX tutorials to run as expected by uninstalling shapely package and uninstall shapely section is missing in this tutorial so I added that section now.