### PR TITLE
Fix: extra negatives causes shape mismatch in FactorizedTopK metrics

### DIFF
--- a/tensorflow_recommenders/tasks/retrieval.py
+++ b/tensorflow_recommenders/tasks/retrieval.py
@@ -199,8 +199,8 @@ class Retrieval(tf.keras.layers.Layer, base.Task):
                 query_embeddings,
                 # Slice to the size of query embeddings
                 # if `candidate_embeddings` contains extra negatives.
-                candidate_embeddings[:tf.shape(query_embeddings)[0]],
-                true_candidate_ids=candidate_ids)
+                candidate_embeddings[:num_queries],
+                true_candidate_ids=candidate_ids[:num_queries])
         )
 
     if compute_batch_metrics:


### PR DESCRIPTION
### The Problem

The Retrieval task already slices the `candidate_embeddings` tensor to remove extra negatives, but it doesn't do the same for the `candidate_ids`. 
This leads to a shape mismatch when calculating the `FactorizedTopK` metrics, if also handling accidental hits.