### PR TITLE
fix keras compatibility bug in factorized_top_k

### DIFF
--- a/tensorflow_recommenders/layers/factorized_top_k.py
+++ b/tensorflow_recommenders/layers/factorized_top_k.py
@@ -373,7 +373,7 @@ class Streaming(TopK):
     self._num_parallel_calls = num_parallel_calls
     self._sorted = sorted_order
 
-    self._counter = self.add_weight("counter", dtype=tf.int32, trainable=False)
+    self._counter = self.add_weight(name="counter", dtype=tf.int32, trainable=False)
 
   def index_from_dataset(
       self,


### PR DESCRIPTION
The bug is summarized by the following issue comment.
https://github.com/tensorflow/recommenders/issues/712#issuecomment-2041163592