### PR TITLE
Revert requirement of tensorflow-macos package for MacOS platforms 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-tensorflow >= 2.9.0; sys_platform != 'darwin'
-tensorflow-macos >= 2.9.0; sys_platform == 'darwin'
+tensorflow >= 2.9.0
 absl-py >= 0.1.6


### PR DESCRIPTION
Hi,

In a [previous PR](https://github.com/tensorflow/recommenders/pull/549), `tensorflow-macos` was added as a dependency to enable installing newer versions of `tensorflow-recommenders` on MacOS-machines, as the package requires `tensorflow >= 2.9.0` and at that time it did not exist for macos. This was included in the [0.7.3 release](https://github.com/tensorflow/recommenders/releases/tag/v0.7.3).

With [TensorFlow 2.16.1](https://github.com/tensorflow/tensorflow/releases/tag/v2.16.1), Apple Silicon users are now advised to install TensorFlow via `pip install tensorflow`. Due to this change, installing the latest `tensorflow-recommenders` via `poetry` fails with a dependency error (Package 'tensorflow-macos' is listed as a dependency of itself), as reported in [issue #713](https://github.com/tensorflow/recommenders/issues/713).

This PR reverts the changes from [PR #549](https://github.com/tensorflow/recommenders/pull/549) to resolve the issue.