### PR TITLE
Fix Keras 3.x compatibility in FactorizedTopK layer

### DIFF
--- a/tensorflow_recommenders/layers/factorized_top_k.py
+++ b/tensorflow_recommenders/layers/factorized_top_k.py
@@ -373,7 +373,7 @@ class Streaming(TopK):
     self._num_parallel_calls = num_parallel_calls
     self._sorted = sorted_order
 
-    self._counter = self.add_weight("counter", dtype=tf.int32, trainable=False)
+    self._counter = self.add_weight(name="counter", dtype=tf.int32, trainable=False)
 
   def index_from_dataset(
       self,


### PR DESCRIPTION
The add_weight() method call in Streaming.init used positional arguments which breaks with Keras 3.x. Changed to keyword argument to maintain compatibility with both Keras 2.x and 3.x versions.

Fixes users getting "Cannot convert ('c','o','u','n','t','e','r') to a shape" error when using TensorFlow 2.16+ with TFRS 0.7.3.

Fixes #712
Fixes #731
Fixes #748
Fixes #754
Fixes #759